### PR TITLE
Patch AXI serializer for compatibility with QuestaSim

### DIFF
--- a/hw/vendor/patches/pulp_platform_axi/0004-param-init.patch
+++ b/hw/vendor/patches/pulp_platform_axi/0004-param-init.patch
@@ -1,0 +1,13 @@
+diff --git a/src/axi_id_serialize.sv b/src/axi_id_serialize.sv
+index 671b38ad..e87d6832 100644
+--- a/src/axi_id_serialize.sv
++++ b/src/axi_id_serialize.sv
+@@ -66,7 +66,7 @@ module axi_id_serialize #(
+   /// Number of Entries in the explicit ID map (default: None)
+   parameter int unsigned IdMapNumEntries = 32'd0,
+   /// Explicit ID map; index [0] in each entry is the input ID to match, index [1] the output ID.
+-  parameter int unsigned IdMap [axi_pkg::iomsb(IdMapNumEntries):0][0:1] = '{default: {32'b0, 32'b0}}
++  parameter int unsigned IdMap[axi_pkg::iomsb(IdMapNumEntries):0][0:1] = '{default: '0}
+ ) (
+   /// Rising-edge clock of both ports
+   input  logic      clk_i,

--- a/hw/vendor/pulp_platform/axi/src/axi_id_serialize.sv
+++ b/hw/vendor/pulp_platform/axi/src/axi_id_serialize.sv
@@ -66,7 +66,7 @@ module axi_id_serialize #(
   /// Number of Entries in the explicit ID map (default: None)
   parameter int unsigned IdMapNumEntries = 32'd0,
   /// Explicit ID map; index [0] in each entry is the input ID to match, index [1] the output ID.
-  parameter int unsigned IdMap [axi_pkg::iomsb(IdMapNumEntries):0][0:1] = '{default: {32'b0, 32'b0}}
+  parameter int unsigned IdMap[axi_pkg::iomsb(IdMapNumEntries):0][0:1] = '{default: '0}
 ) (
   /// Rising-edge clock of both ports
   input  logic      clk_i,


### PR DESCRIPTION
Patch the default initialization of the `IdMap` parameter in `axi_id_serialize.sv` to prevent errors in QuestaSim (vlog-2997 and vopt-13148).