### PR TITLE
Update links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,8 @@ export
 
 ## @section Conda
 conda: util/conda_environment.yml
-	@if conda info --envs | grep -q $(CONDA_ENV_NAME); then \
+	@export CMAKE_POLICY_VERSION_MINIMUM=3.5; \
+	if conda info --envs | grep -q $(CONDA_ENV_NAME); then \
 		echo "Environment $(CONDA_ENV_NAME) exists, updating..."; \
 		conda env update -f util/conda_environment.yml --prune; \
 	else \

--- a/Makefile.venv
+++ b/Makefile.venv
@@ -143,6 +143,14 @@ endif
 endif
 
 ifndef PY
+_PY_OPTION:=python3
+ifeq (ok,$(shell $(_PY_OPTION) -c "print('ok')" $(NULL_STDERR)))
+PY=$(_PY_OPTION)
+$(info $(_PY_AUTODETECT_MSG))
+endif
+endif
+
+ifndef PY
 define _PY_AUTODETECT_ERR
 Could not detect Python interpreter automatically.
 Please specify path to interpreter via PY environment variable.

--- a/docs/source/Extending/eXamples.md
+++ b/docs/source/Extending/eXamples.md
@@ -4,7 +4,7 @@ Here you can find a list of `X-HEEP` based open-source examples. If you want to 
 
 * [CGRA-X-HEEP](https://github.com/esl-epfl/cgra_x_heep): A CGRA loosely coupled with X-HEEP.
 * [F-HEEP](https://github.com/davidmallasen/F-HEEP): System integrating [fpu_ss](https://github.com/pulp-platform/fpu_ss) into X-HEEP via the eXtension interface and cv32e40px.
-* [KALIPSO](https://github.com/vlsi-lab/ntt_intt_kyber) and [KRONOS](https://github.com/vlsi-lab/keccak_integration/tree/keccak_xheep): Loosely-coupled, post-quantum cryptography accelerators for NTT/INTT and Keccak hash function integrated into X-HEEP.
+* [KALIPSO](https://github.com/edge-group-polito/KALIPSO) and [KRONOS](https://github.com/edge-group-polito/keccak_integration/tree/keccak_xheep): Loosely-coupled, post-quantum cryptography accelerators for NTT/INTT and Keccak hash function integrated into X-HEEP.
 
 ## Socsim-Generator: External Co-Simulation Flow for X-HEEP
 

--- a/docs/source/How_to/AreaPlot.md
+++ b/docs/source/How_to/AreaPlot.md
@@ -1,5 +1,5 @@
 # Area Plot
-X-HEEP offers the possibility to visualize post-synthesis area reports using the [area_plot](https://github.com/vlsi-lab/area-plot-post-syn.git) Python package.
+X-HEEP offers the possibility to visualize post-synthesis area reports using the [area_plot](https://github.com/edge-group-polito/area-plot-post-syn.git) Python package.
 The tool, based on [`plotly`](https://plotly.com) `treemap` graphics, provides an interactive interface for hierarchical design exploration, making it easier to analyze the relative area contributions of various submodules and their impact on the overall design.
 
 ![X-Heep area example](./../images/x-heep-area-plot.png)

--- a/docs/source/How_to/Profiling.md
+++ b/docs/source/How_to/Profiling.md
@@ -3,7 +3,7 @@
 ## Overview
 
 X-HEEP supports performance profiling using the
-[rv-profile](https://github.com/vlsi-lab/rv_profile) Python package. This tool
+[rv-profile](https://github.com/edge-group-polito/rv_profile) Python package. This tool
 provides **cycle-accurate profiling** for RISC-V, allowing you to measure how
 many cycles each function consumes during RTL simulation. 
 
@@ -13,7 +13,7 @@ any web browser for analysis.
 
 ![FlameGraph](https://vincenzo-petrolo.github.io/flamegraph_example/flamegraph.svg)
 
-Currently, all cores supported by X-HEEP are compatible with [rv-profile](https://github.com/vlsi-lab/rv_profile).
+Currently, all cores supported by X-HEEP are compatible with [rv-profile](https://github.com/edge-group-polito/rv_profile).
 
 ## Profiling with rv-profile
 

--- a/util/python-requirements.txt
+++ b/util/python-requirements.txt
@@ -18,7 +18,7 @@ git+https://github.com/x-heep/fusesoc.git@ot#egg=fusesoc
 git+https://github.com/x-heep/edalize.git
 
 # RISC-V firmware profiler
-git+https://github.com/vlsi-lab/rv_profile.git
+git+https://github.com/edge-group-polito/rv_profile.git
 
 # Area Plot
-git+https://github.com/vlsi-lab/area-plot-post-syn.git
+git+https://github.com/edge-group-polito/area-plot-post-syn.git


### PR DESCRIPTION
This PR is to update the links to the new GitHub organization of EDGE Group.

Moreover, it adds:
- PY fallback to python3 in Makefile.env
- A DEFINE for forward compatibility of area_plot, this way, if a newer version of CMAKE is available, the 3.5 policies are still applied and pip does not complain