### PR TITLE
i2c set period

### DIFF
--- a/sw/device/lib/sdk/i2c/i2c_sdk.c
+++ b/sw/device/lib/sdk/i2c/i2c_sdk.c
@@ -50,6 +50,7 @@ i2c_result_t initialize_i2c(){
     }
 
     // I2C timing computation
+    i2c_timing_config.clock_period_nanos = clock_period_ns;
     i2c_result = i2c_compute_timing(i2c_timing_config, &i2c_config);
     if(i2c_result != kDifI2cOk) {
         return i2c_result;


### PR DESCRIPTION
period was never set, so i2c was running at 5Hz.
Now it runs correctly at 100kHz. Tested on pynq-z2